### PR TITLE
Fix: load scripts from folders inside api

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -110,7 +110,7 @@ class Application extends events.EventEmitter {
     const files = await fsp.readdir(placePath, { withFileTypes: true });
     for (const file of files) {
       const filePath = path.join(placePath, file.name);
-      if (place !== 'static') await this.loadScript(place, filePath);
+      if (place !== 'static' && !file.isDirectory()) await this.loadScript(place, filePath);
       else if (file.isDirectory()) await this.loadPlace(place, filePath);
       else await this.loadFile(filePath);
     }


### PR DESCRIPTION
Condition if (place !== 'static' && !file.isDirectory()) helps to load folders inside api, but prevent recursively loading scripts from static folder.