### PR TITLE
Use `writableEnded` instead of `finished`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ platform based on [Metarhia technology stack](https://github.com/metarhia) and
 
 ## Requirements
 
-- Node.js v12.5.0 or later (v14 preferred)
+- Node.js v12.9.0 or later (v14 preferred)
 - Linux (tested on Fedora 30, Ubuntu 16, 18, 19 and 20, CentOS 7 and 8)
 - Postgresql 9.5 or later (v11.8 preferred)
 - OpenSSL v1.1.1 or later

--- a/lib/client.js
+++ b/lib/client.js
@@ -38,6 +38,7 @@ class Client {
     const fileExt = path.extname(filePath).substring(1);
     const mimeType = MIME_TYPES[fileExt] || MIME_TYPES.html;
     res.writeHead(200, { ...HEADERS, 'Content-Type': mimeType });
+    if (res.writableEnded) return;
     const data = application.static.get(filePath);
     if (data) res.end(data);
     else this.error(404);
@@ -63,7 +64,7 @@ class Client {
       connection.send(result);
       return;
     }
-    if (res.finished) return;
+    if (res.writableEnded) return;
     res.writeHead(status, { 'Content-Type': MIME_TYPES.json });
     res.end(result);
   }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "homepage": "https://github.com/HowProgrammingWorks/NodejsStarterKit",
   "engines": {
-    "node": ">=12.5.0"
+    "node": ">=12.9.0"
   },
   "devDependencies": {
     "eslint": "^7.4.0"


### PR DESCRIPTION
After node.js v12.9.0 we should handle WritableStream as described here:
https://nodejs.org/api/http.html#http_request_writableended